### PR TITLE
ci: reduce frontend workflow noise

### DIFF
--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -1,16 +1,13 @@
 name: (alpha)Deploy To Cloudflare
 
 on:
-  pull_request:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
   cicd:
-    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/') }}
     uses: mss-boot-io/mss-boot-admin-antd/.github/workflows/cf.yml@main
     with:
       env: alpha

--- a/.github/workflows/alpha.yml
+++ b/.github/workflows/alpha.yml
@@ -10,6 +10,7 @@ permissions:
 
 jobs:
   cicd:
+    if: ${{ github.actor != 'dependabot[bot]' && !startsWith(github.head_ref, 'dependabot/') }}
     uses: mss-boot-io/mss-boot-admin-antd/.github/workflows/cf.yml@main
     with:
       env: alpha

--- a/.github/workflows/beta.yml
+++ b/.github/workflows/beta.yml
@@ -1,9 +1,7 @@
 name: (beta)Deploy To Cloudflare
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -9,15 +9,16 @@ on:
     - cron: "33 20 * * 0"
   workflow_dispatch:
 
-permissions:
-  actions: read
-  contents: read
-  id-token: write
-  security-events: write
+permissions: read-all
 
 jobs:
   scorecard:
     runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      id-token: write
+      security-events: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/aigc/prompts/frontend-ci-cloudflare-dependabot-2026-06-05.zh-CN.md
+++ b/aigc/prompts/frontend-ci-cloudflare-dependabot-2026-06-05.zh-CN.md
@@ -2,11 +2,11 @@
 
 ## 现象
 
-`mss-boot-admin-antd` 的 Dependabot PR 大量触发 `(alpha)Deploy To Cloudflare`，但 Dependabot 无法读取仓库 secret，导致 Cloudflare 发布失败。CI、CodeQL 等基础检查本身不是主要问题。
+`mss-boot-admin-antd` 的 Dependabot PR 大量触发 `(alpha)Deploy To Cloudflare`，但 Dependabot 无法读取仓库 secret，导致 Cloudflare 发布失败。`beta` workflow 也配置为 main push 自动发布 Cloudflare，与“前端不高频发布、可对外展示后再发布”的约束冲突。CI、CodeQL 等基础检查本身不是主要问题。
 
 ## 处理
 
-- 在 alpha Cloudflare workflow 上跳过 `dependabot[bot]` 和 `dependabot/*` 分支。
+- 将 alpha 和 beta Cloudflare workflow 改为 `workflow_dispatch`，发布由维护者确认后手动触发。
 - Scorecard 权限从 workflow 顶层收窄到 job 级别。
 
 ## 验证
@@ -16,4 +16,4 @@
 
 ## 后续
 
-前端仍遵循低频 Cloudflare 发布策略：本地开发和 CI 先验证，只有达到可对外展示状态后才发布到 beta/prod。
+前端仍遵循低频 Cloudflare 发布策略：本地开发和 CI 先验证，只有达到可对外展示状态后才手动发布到 alpha/beta/prod。

--- a/aigc/prompts/frontend-ci-cloudflare-dependabot-2026-06-05.zh-CN.md
+++ b/aigc/prompts/frontend-ci-cloudflare-dependabot-2026-06-05.zh-CN.md
@@ -1,0 +1,19 @@
+# 2026-06-05 前端 CI 失败复盘
+
+## 现象
+
+`mss-boot-admin-antd` 的 Dependabot PR 大量触发 `(alpha)Deploy To Cloudflare`，但 Dependabot 无法读取仓库 secret，导致 Cloudflare 发布失败。CI、CodeQL 等基础检查本身不是主要问题。
+
+## 处理
+
+- 在 alpha Cloudflare workflow 上跳过 `dependabot[bot]` 和 `dependabot/*` 分支。
+- Scorecard 权限从 workflow 顶层收窄到 job 级别。
+
+## 验证
+
+- `go run github.com/rhysd/actionlint/cmd/actionlint@latest`
+- `git diff --check`
+
+## 后续
+
+前端仍遵循低频 Cloudflare 发布策略：本地开发和 CI 先验证，只有达到可对外展示状态后才发布到 beta/prod。


### PR DESCRIPTION
## Summary
- make Cloudflare alpha and beta deploy workflows manual to avoid high-frequency frontend publishing
- keep automated CI/CodeQL checks for pull requests and main pushes
- move Scorecard write permissions from workflow level to the scorecard job
- record the frontend Cloudflare deploy policy in aigc memory

## Tests / 验证
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- git diff --check

## Docs / 文档
- Updated aigc/prompts/frontend-ci-cloudflare-dependabot-2026-06-05.zh-CN.md

## Security / 安全
- Avoids exposing or requiring Cloudflare secrets for Dependabot PRs.
- Narrows default Scorecard workflow permissions to read-only.

## Release / 发布与回滚
- Affects frontend Cloudflare release flow only: alpha/beta deploys are manual, prod remains manual/tag-based. Rollback is reverting this PR.