### PR TITLE
docs: fix frontend readme community signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mss-boot-admin-antd
 
-[![Build Status](https://github.com/mss-boot-io/mss-boot-admin/workflows/CI/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin/releases) [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/mss-boot-io/mss-boot-admin)
+[![CI](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml) [![CodeQL](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/releases) [![License](https://img.shields.io/github/license/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/blob/main/LICENSE)
 
 English | [简体中文](./README.zh-CN.md)
 
@@ -20,6 +20,10 @@ The frontend has undergone comprehensive polish rounds focusing on:
 ## Tutorial
 
 [Online documentation](https://docs.mss-boot-io.top) [Video tutorial](https://space.bilibili.com/597294782/channel/seriesdetail?sid=3881026)
+
+## Community
+
+[Contributing](./CONTRIBUTING.md) [Security](./SECURITY.md) [Support](./SUPPORT.md) [Good first issues](https://github.com/mss-boot-io/mss-boot-admin-antd/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) [AI memory](./aigc/prompts/readme.zh-CN.md)
 
 ## Project address
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # mss-boot-admin-antd
 
-[![Build Status](https://github.com/mss-boot-io/mss-boot-admin/workflows/CI/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin/releases) [![License](https://img.shields.io/github/license/mashape/apistatus.svg)](https://github.com/mss-boot-io/mss-boot-admin)
+[![CI](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml) [![CodeQL](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/releases) [![License](https://img.shields.io/github/license/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/blob/main/LICENSE)
 
 [English](./README.md) | 简体中文
 
@@ -11,6 +11,10 @@
 ## 教程
 
 [在线文档](https://docs.mss-boot-io.top) [视频教程](https://space.bilibili.com/597294782/channel/seriesdetail?sid=3881026)
+
+## 社区
+
+[贡献指南](./CONTRIBUTING.md) [安全策略](./SECURITY.md) [支持渠道](./SUPPORT.md) [适合首次贡献的任务](https://github.com/mss-boot-io/mss-boot-admin-antd/issues?q=is%3Aissue%20is%3Aopen%20label%3A%22good%20first%20issue%22) [AI 记忆](./aigc/prompts/readme.zh-CN.md)
 
 ## 项目地址
 

--- a/aigc/prompts/readme-community-signals-2026-06-05.zh-CN.md
+++ b/aigc/prompts/readme-community-signals-2026-06-05.zh-CN.md
@@ -1,0 +1,18 @@
+# 2026-06-05 README 可信信号修复记忆
+
+## 背景
+
+`mss-boot-admin-antd` README 顶部 badge 指向 `mss-boot-admin` 后端仓库，外部贡献者看到的 CI、Release、License 信号不准确。
+
+## 处理
+
+- 将英文和中文 README badge 改为当前前端仓库的 CI、CodeQL、OpenSSF Scorecard、Release、License。
+- 增加 Contributing、Security、Support、Good first issue、AI memory 入口。
+
+## 验证
+
+- `git diff --check`
+
+## 后续
+
+其他核心仓库 README 也应保持同样的社区入口和 badge 口径。


### PR DESCRIPTION
## Summary
- fix README badges to point to mss-boot-admin-antd instead of the backend repository
- add community links for contributing, security, support, good first issues, and AI memory
- record the README signal fix in aigc memory

## Tests / 验证
- git diff --check

## Docs / 文档
- Updated README.md
- Updated README.zh-CN.md
- Added aigc/prompts/readme-community-signals-2026-06-05.zh-CN.md

## Security / 安全
- Documentation only. Security link now points contributors to the repository policy.

## Release / 发布与回滚
- No runtime release impact. Rollback is reverting this PR.