### PR TITLE
ci: upgrade action runtime versions

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -19,14 +19,14 @@ jobs:
     environment: ${{ inputs.env }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,13 +19,13 @@ jobs:
       CI: true
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup pnpm
-        uses: pnpm/action-setup@v3
+        uses: pnpm/action-setup@v6
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: pnpm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -32,13 +32,13 @@ jobs:
             build-mode: none
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,14 +21,14 @@ jobs:
     name: Release
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup pnpm
-        uses: pnpm/action-setup@v2
+        uses: pnpm/action-setup@v6
         with:
           version: 9
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 18
           cache: pnpm

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -21,7 +21,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           persist-credentials: false
 
@@ -33,6 +33,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: scorecard-results.sarif

--- a/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,8 @@
+# Actions runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：前端主干合并 README 社区信号后全绿，但 CI / CodeQL 中仍有 Node.js 20 runtime 和 CodeQL Action v3 的弃用提示。
+- 处理：将 `actions/checkout`、`actions/setup-node`、`pnpm/action-setup` 升级到 `v6`，将 CodeQL 相关 action 升级到 `v4`。
+- 发布约束：Cloudflare alpha/beta workflow 仍保持 `workflow_dispatch`，本次只是工作流 action 版本升级，不触发高频前端发布。
+- 验收：PR checks 全绿后合并，合并后确认 main 只跑 CI/CodeQL/Mirror/Scorecard，不触发 Cloudflare alpha/beta。
+


### PR DESCRIPTION
## Summary
- upgrade checkout/setup-node/pnpm setup actions to `v6`
- upgrade CodeQL init/analyze/upload-sarif to `v4`
- record the runtime-upgrade context in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified `actions/checkout@v6`, `actions/setup-node@v6`, `pnpm/action-setup@v6`, and `github/codeql-action@v4` tags via GitHub API

## Docs
- Added `aigc/prompts/action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No frontend security behavior changes.
- Keeps CodeQL and SARIF upload actions on the supported major version.

## Release
- CI-only change.
- Cloudflare alpha/beta workflows remain `workflow_dispatch`; this PR must not trigger a frontend Cloudflare deploy.