### PR TITLE
ci: upgrade docker action runtimes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,20 +72,20 @@ jobs:
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Extract metadata (tags, labels) for Docker
       # https://github.com/docker/metadata-action
       - name: Extract Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           flavor: |
@@ -96,7 +96,7 @@ jobs:
             type=sha,prefix=,format=long,enable=true,priority=100
 
       - name: Build and push Docker image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/aigc/prompts/docker-action-runtime-upgrade-2026-06-05.zh-CN.md
+++ b/aigc/prompts/docker-action-runtime-upgrade-2026-06-05.zh-CN.md
@@ -1,0 +1,8 @@
+# Docker action runtime 升级记忆
+
+- 日期：2026-06-05
+- 背景：mss-boot-admin 主干 CI 暴露 Docker 官方 actions 的 Node.js 20 runtime 注解；mss-boot-admin-antd 的 release workflow 使用同一批旧 Docker actions，需要提前同步升级，避免 tag 发布时出现相同提示或未来失败。
+- 处理：将 `docker/login-action` 升级到 `v4`，`docker/setup-buildx-action` 升级到 `v4`，`docker/metadata-action` 升级到 `v6`，`docker/build-push-action` 升级到 `v7`。
+- 发布约束：前端 Cloudflare alpha/beta 发布仍保持手动 `workflow_dispatch`；本次只改 Docker release workflow 的 action runtime，不触发 Cloudflare 发布。
+- 验收：PR checks 验证 CI/CodeQL/Scorecard/Mirror；真正 Docker release 仍由 tag 发布流程在需要时触发。
+


### PR DESCRIPTION
## Summary
- upgrade Docker official actions to their Node 24-compatible major versions
- keep the existing release image tag/build/push behavior unchanged
- record the runtime follow-up in `aigc/prompts`

## Tests
- `git diff --check`
- parsed all `.github/workflows/*` files with Ruby YAML
- verified Docker action latest releases use `node24` via GitHub API

## Docs
- Added `aigc/prompts/docker-action-runtime-upgrade-2026-06-05.zh-CN.md`.

## Security
- No frontend security behavior changes.
- Removes Docker action Node.js 20 runtime warnings from the release image path.

## Release
- Frontend Cloudflare alpha/beta workflows remain manual `workflow_dispatch`; this PR does not trigger a Cloudflare deploy.
