### PR TITLE
ci: delegate setup to GitHub

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,14 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "area/frontend"
       - "type/security"
@@ -11,6 +19,14 @@ updates:
     directory: "/workers-site"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 3
+    groups:
+      workers-site-minor-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
     labels:
       - "area/devops"
       - "type/security"
@@ -18,6 +34,11 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 5
+    groups:
+      github-actions:
+        patterns:
+          - "*"
     labels:
       - "area/devops"
       - "type/security"

--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -17,6 +17,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     environment: ${{ inputs.env }}
+    concurrency:
+      group: cloudflare-${{ inputs.env }}
+      cancel-in-progress: false
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -1,0 +1,32 @@
+name: Copilot Setup Steps
+
+on:
+  workflow_dispatch:
+  push:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+  pull_request:
+    paths:
+      - .github/workflows/copilot-setup-steps.yml
+
+permissions:
+  contents: read
+
+jobs:
+  copilot-setup-steps:
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v6
+        with:
+          version: 9
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 18
+          cache: pnpm
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -2,9 +2,6 @@ name: (prod)Deploy To Cloudflare
 
 on:
   workflow_dispatch:
-  push:
-    tags:
-      - 'v*.*.*'
 
 permissions:
   contents: read

--- a/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
+++ b/aigc/prompts/github-copilot-setup-steps-2026-06-05.zh-CN.md
@@ -1,0 +1,27 @@
+# GitHub Copilot Setup Steps
+
+日期：2026-06-05
+
+## 背景
+
+前端不能高频发布到 Cloudflare，但仍可以把本地开发、PR 检查、类型问题和
+小范围 UI 修复更多交给 GitHub Copilot coding agent 准备。
+
+## 已落地
+
+- 新增 `.github/workflows/copilot-setup-steps.yml`。
+- 工作流只在手动触发、或该 workflow 文件变更时运行。
+- 代理环境步骤包括 checkout、`pnpm/action-setup@v6`、
+  `actions/setup-node@v6` 和 `pnpm install --frozen-lockfile`。
+- 将 `.github/workflows/prod.yml` 调整为仅保留人工触发，避免 tag push
+  自动触发 Cloudflare prod 发布。
+- 在 `.github/workflows/cf.yml` 增加按环境分组的部署并发锁，避免同一
+  Cloudflare 环境并发发布。
+- 为 Dependabot 增加 npm minor/patch 分组和 GitHub Actions 分组，降低依赖
+  PR 数量和 CI 噪音。
+
+## 约束
+
+- 该 workflow 只做环境预热，不触发 Cloudflare 发布。
+- alpha/beta/prod Cloudflare 发布必须保持人工 `workflow_dispatch`。
+- 真实对外环境发布前仍需本地开发验证、CI 通过和冒烟测试。


### PR DESCRIPTION
## Summary
- add Copilot coding-agent setup steps for frontend dependency prewarming
- keep Cloudflare prod deployment manual by removing tag-push deploy trigger
- add Cloudflare environment concurrency and Dependabot grouping to reduce release/CI noise
- record repository-local AIGC memory

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'\n- git diff --check\n\n## Docs\n- Adds repository-local AIGC memory under aigc/prompts/.\n\n## Security\n- Keeps the Copilot setup workflow read-only with contents: read.\n- Does not expose Cloudflare tokens or change secret names.\n\n## Release / compatibility / rollback\n- Frontend Cloudflare alpha, beta, and prod release workflows remain manual workflow_dispatch paths.\n- Removing prod tag-push deploy prevents accidental release from tags.\n- Rollback is restoring the tag trigger if the maintainer explicitly wants tag-based prod deploy again.\n\n## Notes\n- Alpha, beta, and prod Cloudflare deployments remain manual workflow_dispatch paths.