### PR TITLE
ci: use Node 22 for frontend workflows

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
 
       - name: Install Dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 22
           cache: pnpm
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/aigc/prompts/frontend-node22-dependency-baseline-2026-06-05.zh-CN.md
+++ b/aigc/prompts/frontend-node22-dependency-baseline-2026-06-05.zh-CN.md
@@ -1,0 +1,24 @@
+# Frontend Node 22 Dependency Baseline
+
+日期：2026-06-05
+
+## 背景
+
+前端依赖升级进入 Node 20+ / Node 22+ 运行时区间：
+
+- `cross-env@10` 要求 Node 20+。
+- `@cloudflare/kv-asset-handler@0.5.x` 在 `workers-site` 中要求 Node 22+。
+- GitHub Actions 组升级后，部分 action 运行时也开始面向 Node 24。
+
+## 已落地
+
+- 将前端 CI、release、Cloudflare reusable workflow、Copilot setup workflow
+  的 `actions/setup-node` 版本从 Node 18 调整为 Node 22。
+- Cloudflare alpha/beta/prod 发布触发规则保持不变，不因为该基线调整自动发布。
+- 前端 release 仍只负责 GitHub Release 和镜像构建，不触发 Cloudflare 发布。
+
+## 约束
+
+- `admin-beta` Cloudflare 环境仍必须在本地开发、CI 通过、功能可对外展示后再人工发布。
+- tag 发布前端版本时不得自动触发 Cloudflare prod 发布。
+- 后续新增 Node 版本相关依赖时，需要优先让 GitHub Actions 基线与依赖引擎要求一致。


### PR DESCRIPTION
## Summary
- move frontend CI, release, Cloudflare, and Copilot setup workflows from Node 18 to Node 22
- keep Cloudflare deployment triggers unchanged and manual-only where already configured
- record the Node 22 dependency baseline in aigc memory

## Tests
- go run github.com/rhysd/actionlint/cmd/actionlint@latest
- GitHub Actions CI on this PR

## Docs
- added aigc/prompts/frontend-node22-dependency-baseline-2026-06-05.zh-CN.md

## Security
- no secret, permission, or auth surface changes
- keeps Cloudflare deployment triggering rules unchanged

## Release / Compatibility
- prepares v0.7.x frontend release for dependencies that require Node 20+ / Node 22+
- does not trigger Cloudflare alpha/beta/prod deployment by itself
