### PR TITLE
docs: align testing commands with package scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,16 +176,16 @@ The project follows strict testing requirements with comprehensive test coverage
 - **Tools**: React Testing Library + Mock Service Worker (MSW)
 - **Run command**:
   ```bash
-  pnpm test:integration
+  pnpm test
   ```
 
-#### 3. End-to-End (E2 E) Tests
+#### 3. End-to-End (E2E) Tests
 - **Full Stack Testing**: Uses Playwright for browser automation
 - **Critical user flows**: login, CRUD operations, permissions
 - **Mobile testing**: Comprehensive iPhone 12 Pro viewport tests
 - **Run command**: 
   ```bash
-  pnpm e2e
+  pnpm run test:e2e
   ```
 
 ### Coverage Requirements
@@ -219,7 +219,7 @@ The application features comprehensive mobile H5 adaptation with responsive desi
 
 ### Development Guidelines
 
-- **Testing Mobile**: Use `pnpm e2e --project='iPhone 12 Pro'` to run mobile-specific tests
+- **Testing Mobile**: Use `pnpm run test:e2e -- --project='iPhone 12 Pro'` to run mobile-specific tests
 - **Responsive Breakpoints**: Mobile layout activates below 768px width
 - **Touch Targets**: Ensure all interactive elements are at least 44px for touch accessibility
 

--- a/TESTING.md
+++ b/TESTING.md
@@ -159,21 +159,21 @@ E2E tests are located in the `e2e/` directory and use Playwright for browser aut
 
 ```bash
 # Install Playwright browsers (first time only)
-pnpm exec playwright install
+pnpm run playwright:install
 
 # Run all E2E tests
-pnpm e2e
+pnpm run test:e2e
 
 # Run E2E tests in headed mode (visible browser)
-pnpm e2e --headed
+pnpm run test:e2e -- --headed
 
 # Run specific test file
-pnpm e2e e2e/login.spec.ts
+pnpm run test:e2e -- e2e/login.spec.ts
 
 # Run tests with specific browser
-pnpm e2e --project=chromium
-pnpm e2e --project=firefox  
-pnpm e2e --project=webkit
+pnpm run test:e2e -- --project=chromium
+pnpm run test:e2e -- --project=firefox
+pnpm run test:e2e -- --project=webkit
 ```
 
 ### Example: Login E2E Test
@@ -232,10 +232,10 @@ const config = {
 
 ```bash
 # Run mobile-specific tests
-pnpm e2e --project='iPhone 12 Pro'
+pnpm run test:e2e -- --project='iPhone 12 Pro'
 
 # Run all tests including mobile
-pnpm e2e
+pnpm run test:e2e
 ```
 
 ### Example: Mobile Navigation Test
@@ -315,7 +315,7 @@ Follow this workflow when developing new features:
 2. TESTING PHASE (MANDATORY)
    ├── Unit Tests: pnpm test
    ├── Integration Tests: pnpm test
-   └── E2E Tests: pnpm e2e (for major features)
+   └── E2E Tests: pnpm run test:e2e (for major features)
 
 3. VERIFICATION PHASE
    ├── Check test coverage (≥80%)
@@ -335,7 +335,7 @@ pnpm test --coverage
 # Coverage summary must show ≥80%
 
 # Run E2E tests for major changes
-pnpm e2e
+pnpm run test:e2e
 ```
 
 ## Writing Tests
@@ -386,10 +386,10 @@ jobs:
   test:
     steps:
       - name: Run unit tests
-        run: pnpm test --coverage
-      
+        run: pnpm test -- --runInBand
+
       - name: Run E2E tests
-        run: pnpm e2e
+        run: pnpm run test:e2e
 ```
 
 ### Pre-commit Hooks
@@ -398,16 +398,16 @@ The project uses Husky for pre-commit hooks:
 
 ```bash
 # .husky/pre-commit
-pnpm lint
-pnpm test:unit
+npx --no-install lint-staged
 ```
 
-### Pre-push Hooks
+### Local Verification
 
 ```bash
-# .husky/pre-push
+pnpm run lint
+pnpm tsc
 pnpm test
-pnpm test:integration
+pnpm run build:local
 ```
 
 ## Test Environment Setup
@@ -423,7 +423,7 @@ go run . server
 
 # Then run E2E tests
 cd ../mss-boot-admin-antd
-pnpm e2e
+pnpm run test:e2e
 ```
 
 ### Environment Variables
@@ -448,11 +448,8 @@ pnpm test --inspect-brk --runInBand src/hooks/useUser.test.ts
 ### E2E Test Debugging
 
 ```bash
-# Run in debug mode
-pnpm e2e --debug
-
-# Slow motion mode
-pnpm e2e --slowMo=500
+# Open the Playwright inspector for step-by-step debugging
+pnpm run test:e2e -- --debug
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- align README and TESTING.md commands with the scripts defined in package.json
- replace stale E2E and integration test commands with the existing `test:e2e` and `test` scripts
- update the documented Husky pre-commit hook and local verification commands

## Verification

- `git diff --check`
- Verified `package.json` contains `test`, `test:e2e`, `playwright:install`, `lint`, `tsc`, and `build:local`

Resolves #73