### PR TITLE
ci: make release workflow idempotent

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,19 +56,40 @@ jobs:
           name: dist-release
           path: dist
 
-      - name: Release
-        uses: softprops/action-gh-release@v3
-        with:
-          generate_release_notes: true
-          files: |
-            dist.tar.gz
-            dist-local.tar.gz
-          prerelease: false
-          body: |
-            ## Pull Image
-            ```shell
-            docker pull ghcr.io/${{ github.repository }}:${{ github.ref }}
-            ```
+      - name: Upsert release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+
+          tag="${GITHUB_REF_NAME}"
+          title="mss-boot-admin-antd ${tag}"
+          body="$(mktemp)"
+          cat > "${body}" <<'EOF'
+          ## Pull Image
+          ```shell
+          docker pull ghcr.io/${{ github.repository }}:${{ github.ref_name }}
+          ```
+          EOF
+
+          if gh release view "${tag}" >/dev/null 2>&1; then
+            gh release edit "${tag}" \
+              --title "${title}" \
+              --notes-file "${body}" \
+              --draft=false \
+              --prerelease=false
+          else
+            gh release create "${tag}" \
+              --verify-tag \
+              --title "${title}" \
+              --notes-file "${body}"
+          fi
+
+          gh release upload "${tag}" \
+            dist.tar.gz \
+            dist-local.tar.gz \
+            --clobber
 
       - name: Log into registry ${{ env.REGISTRY }}
         if: github.event_name != 'pull_request'

--- a/aigc/prompts/release-upsert-workflow-2026-06-09.zh-CN.md
+++ b/aigc/prompts/release-upsert-workflow-2026-06-09.zh-CN.md
@@ -1,0 +1,25 @@
+# mss-boot-admin-antd release upsert 工作流记录
+
+## 背景
+
+- 记录时间：2026-06-09
+- 影响文件：`.github/workflows/release.yml`
+- 触发场景：推送 `v*.*.*` tag 后构建前端产物、发布 GitHub Release、推送 GHCR 镜像。
+
+## 问题
+
+前端 release workflow 使用 `softprops/action-gh-release` 直接创建 release。若 tag workflow 被重跑，或 release 已经存在，可能出现和后端相同的 `already_exists` 失败，导致公开流水线红灯。
+
+## 修复
+
+- 改为 `gh release view` 判断 release 是否已存在。
+- 已存在时执行 `gh release edit`，更新标题、notes、draft、prerelease 状态。
+- 不存在时执行 `gh release create --verify-tag --notes-file`，保留自定义镜像拉取说明。
+- release step 设置 `GH_REPO=${{ github.repository }}`，避免 `gh` 依赖当前 git remote 推断仓库。
+- 统一在 release 存在后执行 `gh release upload --clobber` 上传 `dist.tar.gz` 与 `dist-local.tar.gz`。
+- release notes 中的镜像拉取命令使用 `github.ref_name` 作为 tag。
+
+## 验证
+
+- workflow YAML 通过 `git diff --check`。
+- 后续新 tag 或重复触发 tag workflow 时，GitHub Release 产物应可被覆盖更新，不再因同 tag release 已存在而红灯。


### PR DESCRIPTION
## Summary

- make the frontend tag release workflow idempotent with `gh release view/create/edit`
- upload release assets with `gh release upload --clobber` after the release exists
- fix the release note image pull example to use `github.ref_name`
- record the release workflow decision in repository-local `aigc` memory

## Tests / Validation

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/release.yml')"`
- `git diff --check`

## Docs Impact

- Added `aigc/prompts/release-upsert-workflow-2026-06-09.zh-CN.md` to record the release workflow decision and the duplicate-tag failure prevention.

## Security Impact

- No secret handling or runtime permissions were expanded.
- The workflow continues to use the built-in `GITHUB_TOKEN` for release create/edit/upload and GHCR steps keep their existing permissions.

## Release / Compatibility / Rollback Impact

- Tag release behavior becomes idempotent: existing releases are edited, missing releases are created, and dist assets are uploaded with `--clobber`.
- No frontend runtime code or Cloudflare deployment behavior changes.
- Rollback path: revert this workflow change to restore the previous `softprops/action-gh-release` behavior.