### PR TITLE
chore: align package metadata with Node 22

### DIFF
--- a/.github/workflows/cf.yml
+++ b/.github/workflows/cf.yml
@@ -26,8 +26,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -21,8 +21,6 @@ jobs:
         uses: actions/checkout@v6
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,8 +25,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v6
-        with:
-          version: 9
       - name: Setup Node
         uses: actions/setup-node@v6
         with:

--- a/aigc/prompts/package-metadata-node22-2026-06-09.zh-CN.md
+++ b/aigc/prompts/package-metadata-node22-2026-06-09.zh-CN.md
@@ -1,0 +1,16 @@
+# package metadata / Node 22 基线记忆
+
+- 日期：2026-06-09
+- 仓库：mss-boot-admin-antd
+- 背景：前端 CI、Cloudflare 发布流水线、Copilot setup 均已使用 Node 22 与 pnpm 9，`package.json` 仍声明 `node >=12.0.0`，且项目描述继续突出已经降级、即将废弃的“虚拟模型”能力。
+- 决策：
+  - `packageManager` 固定为 `pnpm@9.15.9`，与 lockfile v9 和流水线一致。
+  - `engines.node` 调整为 `>=22.0.0`，`engines.pnpm` 调整为 `>=9.0.0`。
+  - package 描述改为开源治理控制台视角，突出 RBAC、组织/菜单/API 治理、配置、国际化、可观测性和 public beta 工作流。
+- CI 修正：
+  - `pnpm/action-setup@v6` 会同时读取 workflow `version` 与 package.json `packageManager`。
+  - 两处同时声明会触发 `Multiple versions of pnpm specified`，因此 CI、Cloudflare、Release、Copilot setup 均移除显式 `version: 9`，统一从 `packageManager` 解析 `pnpm@9.15.9`。
+- 约束：
+  - 虚拟模型是 legacy/degraded 功能，不再作为前端对外主卖点。
+  - 前端不能高频发布到 Cloudflare；本地开发先对接 alpha 后端，完整验证后再发布 beta/prod。
+  - 多 git workspace 的组织级记忆仍必须同步落盘到 mss-boot-docs/aigc，避免线程压缩或仓库切换后丢失。

--- a/package.json
+++ b/package.json
@@ -2,7 +2,8 @@
   "name": "mss-boot-admin",
   "version": "1.0.0",
   "private": false,
-  "description": "基于Gin + React + Atndv5 + Umiv4 + mss-boot 的前后端分离权限管理系统,支持功能:多租户 角色 用户 菜单 国际化 系统配置 权限 虚拟模型 通知 字典, beta环境: https://admin-beta.mss-boot-io.top swagger: https://mss-boot-io.github.io/mss-boot-admin/swagger.json",
+  "description": "React + Ant Design v5 governance console for mss-boot, focused on RBAC, organization/menu/API governance, config, i18n, observability, and public beta workflows.",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "analyze": "cross-env ANALYZE=1 max build",
     "build": "max build",
@@ -108,6 +109,7 @@
     "umi-presets-pro": "^2.0.2"
   },
   "engines": {
-    "node": ">=12.0.0"
+    "node": ">=22.0.0",
+    "pnpm": ">=9.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- Align package metadata with the Node 22 / pnpm 9 baseline already used by CI and Cloudflare workflows.
- Add `packageManager` so contributors and AI agents resolve `pnpm@9.15.9` from package metadata.
- Remove duplicate `version: 9` declarations from pnpm setup workflows because `pnpm/action-setup@v6` rejects simultaneous workflow and `packageManager` versions.
- Refresh the package description around the governance console direction and avoid presenting virtual models as a primary capability, because that feature is legacy/degraded.
- Record the decision in repository-local `aigc` memory.

## Tests
- `node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json','utf8')); console.log(pkg.packageManager, pkg.engines.node, pkg.engines.pnpm)"`
- `pnpm install --frozen-lockfile`
- `pnpm build`
- workflow YAML parse for `.github/workflows/*.yml`

## Docs
- Repository-local AIGC memory updated: `aigc/prompts/package-metadata-node22-2026-06-09.zh-CN.md`.

## Security
- No secret, permission, or authentication behavior changed.
- This only aligns runtime/toolchain metadata and workflow setup.

## Release / Compatibility
- No Cloudflare release is triggered by this PR.
- CI, Cloudflare, Release, and Copilot setup now use the package-level pnpm version to avoid setup-time version conflicts.
- Contributor local setup should now use Node 22+ and pnpm 9+.