### PR TITLE
docs: add frontend environment matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # mss-boot-admin-antd
 
-[![CI](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml) [![CodeQL](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/releases) [![License](https://img.shields.io/github/license/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/blob/main/LICENSE)
+[![CI](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml) [![CodeQL](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml/badge.svg?branch=main)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/releases) [![License](https://img.shields.io/github/license/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/blob/main/LICENSE)
 
 English | [简体中文](./README.zh-CN.md)
 
@@ -70,7 +70,8 @@ The frontend has undergone comprehensive polish rounds focusing on:
 
 - Install golang1.21+
 - Install mysql8.0+
-- Install nodejs18.16.0+
+- Install Node.js 22+
+- Install pnpm 9.x
 
 ## 📦 Quick start
 
@@ -114,10 +115,24 @@ go run main.go server
 # Enter the front-end project
 cd mss-boot-admin-antd
 # Install dependencies
-npm install
+pnpm install
 # Start the front-end service
-npm run start
+pnpm start:dev
 ```
+
+## Frontend Environment Matrix
+
+The frontend uses `UMI_ENV` and `REACT_APP_ENV` to choose the environment-specific config. `API_URL` is defined in the matching `config/config.prod.*.ts` file or by the dev proxy.
+
+| Context | Command | API target | Usage |
+| --- | --- | --- | --- |
+| Local development | `pnpm start:dev` or `pnpm start:no-mock` | Dev proxy to `http://localhost:8080` for `/admin/` and `/public/` | Use with a local `mss-boot-admin` backend. |
+| Local build | `pnpm build:local` | `http://localhost:8080` | Validate a production-style bundle against a local backend. |
+| Alpha | `pnpm start:alpha` / `pnpm build:alpha` | `https://admin-api-alpha.mss-boot-io.top` | Development backend environment for integration checks. |
+| Beta | `pnpm start:beta` / `pnpm build:beta` | `https://admin-api-beta.mss-boot-io.top` | Public beta target after local and CI verification. |
+| Production | `pnpm start:prod` / `pnpm build:prod` | `https://admin-api.mss-boot-io.top` | Production release build target. |
+
+CI and Cloudflare workflows use Node.js 22 and pnpm 9. Cloudflare alpha, beta, and production workflows are manual `workflow_dispatch` deployments; PRs, Dependabot branches, and normal `codex/**` review branches should not publish frontend changes.
 
 ## 📨 Interaction
 
@@ -164,14 +179,16 @@ The project follows strict testing requirements with comprehensive test coverage
 ### Test Types
 
 #### 1. Unit Tests
-- **Location**: `__tests__/*.test.ts` or `*.test.tsx` 
+
+- **Location**: `__tests__/*.test.ts` or `*.test.tsx`
 - **Minimum coverage**: **80%**
-- **Run command**: 
+- **Run command**:
   ```bash
   pnpm test --coverage
   ```
 
-#### 2. Integration Tests  
+#### 2. Integration Tests
+
 - **Focus**: Component interactions with API mocks
 - **Tools**: React Testing Library + Mock Service Worker (MSW)
 - **Run command**:
@@ -180,21 +197,22 @@ The project follows strict testing requirements with comprehensive test coverage
   ```
 
 #### 3. End-to-End (E2E) Tests
+
 - **Full Stack Testing**: Uses Playwright for browser automation
 - **Critical user flows**: login, CRUD operations, permissions
 - **Mobile testing**: Comprehensive iPhone 12 Pro viewport tests
-- **Run command**: 
+- **Run command**:
   ```bash
   pnpm run test:e2e
   ```
 
 ### Coverage Requirements
 
-| Component | Unit Tests | Integration Tests | E2E Tests | Min Coverage |
-|-----------|-----------|-------------------|-----------|--------------|
-| Hooks | ✅ Required | Optional | N/A | 80% |
-| Components | ✅ Required | Optional | Optional | 75% |
-| Utils | ✅ Required | Optional | N/A | 90% |
+| Component  | Unit Tests  | Integration Tests | E2E Tests | Min Coverage |
+| ---------- | ----------- | ----------------- | --------- | ------------ |
+| Hooks      | ✅ Required | Optional          | N/A       | 80%          |
+| Components | ✅ Required | Optional          | Optional  | 75%          |
+| Utils      | ✅ Required | Optional          | N/A       | 90%          |
 
 Detailed testing instructions are available in [TESTING.md](./TESTING.md).
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -1,6 +1,6 @@
 # mss-boot-admin-antd
 
-[![CI](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml) [![CodeQL](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml/badge.svg)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/releases) [![License](https://img.shields.io/github/license/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/blob/main/LICENSE)
+[![CI](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/ci.yml) [![CodeQL](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/codeql.yml) [![OpenSSF Scorecard](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml/badge.svg?branch=main)](https://github.com/mss-boot-io/mss-boot-admin-antd/actions/workflows/scorecard.yml) [![Release](https://img.shields.io/github/v/release/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/releases) [![License](https://img.shields.io/github/license/mss-boot-io/mss-boot-admin-antd.svg?style=flat-square)](https://github.com/mss-boot-io/mss-boot-admin-antd/blob/main/LICENSE)
 
 [English](./README.md) | 简体中文
 
@@ -61,7 +61,8 @@
 
 - 安装 golang1.21+
 - 安装 mysql8.0+
-- 安装 nodejs18.16.0+
+- 安装 Node.js 22+
+- 安装 pnpm 9.x
 
 ## 📦 快速开始
 
@@ -105,10 +106,24 @@ go run main.go server
 # 进入前端项目
 cd mss-boot-admin-antd
 # 安装依赖
-npm install
+pnpm install
 # 启动前端服务
-npm run start
+pnpm start:dev
 ```
+
+## 前端环境矩阵
+
+前端通过 `UMI_ENV` 与 `REACT_APP_ENV` 选择环境配置。`API_URL` 由对应的 `config/config.prod.*.ts` 文件定义，本地开发也会使用 dev proxy。
+
+| 场景 | 命令 | API 目标 | 用途 |
+| --- | --- | --- | --- |
+| 本地开发 | `pnpm start:dev` 或 `pnpm start:no-mock` | `/admin/`、`/public/` 通过 dev proxy 转发到 `http://localhost:8080` | 对接本地 `mss-boot-admin` 后端。 |
+| 本地构建 | `pnpm build:local` | `http://localhost:8080` | 以生产构建方式验证本地后端。 |
+| Alpha | `pnpm start:alpha` / `pnpm build:alpha` | `https://admin-api-alpha.mss-boot-io.top` | 开发后端环境，用于联调验证。 |
+| Beta | `pnpm start:beta` / `pnpm build:beta` | `https://admin-api-beta.mss-boot-io.top` | 对外 beta 目标，需先完成本地和 CI 验证。 |
+| Production | `pnpm start:prod` / `pnpm build:prod` | `https://admin-api.mss-boot-io.top` | 生产发布构建目标。 |
+
+CI 与 Cloudflare workflow 使用 Node.js 22 和 pnpm 9。Cloudflare alpha、beta、prod 发布均保持手动 `workflow_dispatch`；PR、Dependabot 分支和普通 `codex/**` 审查分支不应自动发布前端。
 
 ## 📨 互动
 

--- a/aigc/prompts/frontend-readme-env-matrix-2026-06-09.zh-CN.md
+++ b/aigc/prompts/frontend-readme-env-matrix-2026-06-09.zh-CN.md
@@ -1,0 +1,17 @@
+# 前端 README 环境矩阵记忆
+
+- 日期：2026-06-09
+- 仓库：mss-boot-admin-antd
+- 对应 issue：#71、#72
+
+## 本轮处理
+
+- README / README.zh-CN 的 workflow badges 增加 `branch=main`，明确展示本前端仓库主分支的 CI、CodeQL、OpenSSF Scorecard 状态。
+- 准备工作从旧的 Node 18 / npm 描述调整为 Node.js 22 + pnpm 9，与当前 GitHub Actions、Cloudflare workflow 保持一致。
+- 新增前端环境矩阵，覆盖 local、alpha、beta、prod 的命令、API 目标和使用边界。
+- 明确 Cloudflare alpha/beta/prod 发布均为手动 `workflow_dispatch`，普通 PR、Dependabot、`codex/**` 分支不应触发前端发布。
+
+## 注意
+
+- `package.json` 的 Node/pnpm 元数据由安全依赖收敛 PR 单独处理；本轮只修 README 和本地记忆。
+- 未包含 Cloudflare account、zone、token 等外部账号或私密信息。


### PR DESCRIPTION
## Summary

This PR improves contributor-facing README guidance for the frontend repository.

It:

- pins README workflow badges to the `mss-boot-admin-antd` main branch for CI, CodeQL, and OpenSSF Scorecard
- updates quick-start frontend tooling from npm/Node 18-era instructions to Node.js 22 + pnpm 9 guidance that matches current GitHub Actions and Cloudflare workflows
- adds an English and Chinese frontend environment matrix for local, alpha, beta, and production contexts
- records the decision in `aigc/prompts/frontend-readme-env-matrix-2026-06-09.zh-CN.md`

Closes #71.
Closes #72.

## Documentation Impact

README.md and README.zh-CN.md now explain which command points to which API environment without exposing Cloudflare account IDs, zone IDs, tokens, or private credentials.

## Security Notes

No secrets are added. The only account/password text in README remains the existing public beta demo account.

## Tests Impact

No runtime code, package scripts, workflows, or API configs are changed. The relevant tests for this docs-only PR are Markdown formatting, diff hygiene, and static README link/environment checks.

## Verification

- `npx -y prettier@2.8.8 --check README.md README.zh-CN.md aigc/prompts/frontend-readme-env-matrix-2026-06-09.zh-CN.md`
- `git diff --check`
- static README workflow-link check confirming CI, CodeQL, and Scorecard badges point to `mss-boot-admin-antd`
- static README environment check confirming alpha/beta API domains and the manual `workflow_dispatch` release note are present

## Release Safety

Docs-only change. No frontend build or Cloudflare deployment was triggered.