### PR TITLE
chore: pin remaining vulnerable frontend deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,8 @@
     "swagger-ui-dist": "^5.32.6",
     "ts-node": "^10.9.1",
     "typescript": "^4.9.5",
-    "umi-presets-pro": "^2.0.2"
+    "umi-presets-pro": "^2.0.2",
+    "webpack": "5.107.2"
   },
   "engines": {
     "node": ">=22.0.0",
@@ -113,6 +114,7 @@
   "pnpm": {
     "overrides": {
       "@babel/plugin-transform-modules-systemjs": "7.29.7",
+      "@remix-run/router": "1.23.3",
       "@tootallnate/once": "2.0.1",
       "axios": "0.32.0",
       "braft-editor>immutable": "3.8.3",
@@ -122,9 +124,14 @@
       "draftjs-utils>immutable": "3.8.3",
       "flatted": "3.4.2",
       "js-cookie": "3.0.8",
+      "js-yaml@3.14.1": "3.14.2",
+      "js-yaml@4.1.0": "4.2.0",
+      "minimatch@3.1.2": "3.1.4",
+      "minimatch@8.0.4": "8.0.6",
       "picomatch": "2.3.2",
       "postcss": "8.5.15",
       "qs": "6.15.2",
+      "webpack": "5.107.2",
       "yaml": "1.10.3"
     }
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.7
+  '@remix-run/router': 1.23.3
   '@tootallnate/once': 2.0.1
   axios: 0.32.0
   braft-editor>immutable: 3.8.3
@@ -15,9 +16,14 @@ overrides:
   draftjs-utils>immutable: 3.8.3
   flatted: 3.4.2
   js-cookie: 3.0.8
+  js-yaml@3.14.1: 3.14.2
+  js-yaml@4.1.0: 4.2.0
+  minimatch@3.1.2: 3.1.4
+  minimatch@8.0.4: 8.0.6
   picomatch: 2.3.2
   postcss: 8.5.15
   qs: 6.15.2
+  webpack: 5.107.2
   yaml: 1.10.3
 
 importers:
@@ -120,7 +126,7 @@ importers:
         version: 4.6.61(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(stylelint@13.13.1)(typescript@4.9.5)
       '@umijs/max':
         specifier: ^4.6.61
-        version: 4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react-dom@18.2.17)(@types/react@18.2.41)(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+        version: 4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react-dom@18.2.17)(@types/react@18.2.41)(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       cross-env:
         specifier: ^10.1.0
         version: 10.1.0
@@ -162,7 +168,10 @@ importers:
         version: 4.9.5
       umi-presets-pro:
         specifier: ^2.0.2
-        version: 2.0.3(kea5y674igzsfvf4iconbttr7e)
+        version: 2.0.3(5pzn2vysq3bk52aie2jkmolqri)
+      webpack:
+        specifier: 5.107.2
+        version: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
 packages:
 
@@ -2274,8 +2283,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@remix-run/router@1.13.1':
-    resolution: {integrity: sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==}
+  '@remix-run/router@1.23.3':
+    resolution: {integrity: sha512-4An71tdz9X8+3sI4Qqqd2LWd9vS39J7sqd9EU4Scw7TJE/qB10Flv/UuqbPVgfQV9XoK8Np6jNquZitnZq5i+Q==}
     engines: {node: '>=14.0.0'}
 
   '@scarf/scarf@1.4.0':
@@ -2556,14 +2565,8 @@ packages:
   '@types/d3-timer@3.0.2':
     resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
 
-  '@types/eslint-scope@3.7.7':
-    resolution: {integrity: sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==}
-
   '@types/eslint@7.29.0':
     resolution: {integrity: sha512-VNcvioYDH8/FxaeTKkM4/TiTwt6pBV9E3OfGmvaw8tPl0rrHCJ4Ll15HRT+pMiFAf/MLQvAzC+6RzUMEL9Ceng==}
-
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
 
   '@types/estree@1.0.5':
     resolution: {integrity: sha512-/kYRxGDLWzHOB7q+wtSUQlFrtcdUccpfy+X+9iMBpHK8QLLhx2wIPYuS5DYtR9Wa/YlZAbIovy7qVdB1Aq6Lyw==}
@@ -3026,7 +3029,7 @@ packages:
       react-refresh: '>=0.10.0 <1.0.0'
       sockjs-client: ^1.4.0
       type-fest: '>=0.17.0 <5.0.0'
-      webpack: '>=4.43.0 <6.0.0'
+      webpack: 5.107.2
       webpack-dev-server: 3.x || 4.x
       webpack-hot-middleware: 2.x
       webpack-plugin-serve: 0.x || 1.x
@@ -3226,11 +3229,11 @@ packages:
   acorn-globals@7.0.1:
     resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
 
-  acorn-import-assertions@1.9.0:
-    resolution: {integrity: sha512-cmMwop9x+8KFhxvKrKfPYmN6/pKTYYHBqLa0DfvVZcKMJWNyWLnaqND7dx/qn66R7ewM1UX5XMaDVP5wlVTaVA==}
-    deprecated: package has been renamed to acorn-import-attributes
+  acorn-import-phases@1.0.4:
+    resolution: {integrity: sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==}
+    engines: {node: '>=10.13.0'}
     peerDependencies:
-      acorn: ^8
+      acorn: ^8.14.0
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3606,14 +3609,8 @@ packages:
     resolution: {integrity: sha512-z0M+byMThzQmD9NILRniCUXYsYpjwnlO8N5uCFaCqIOpqRsJCrQL9NK3JsD67CN5a08nF5oIL2bD6loTdHOuKw==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@1.1.11:
-    resolution: {integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==}
-
   brace-expansion@1.1.15:
     resolution: {integrity: sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==}
-
-  brace-expansion@2.0.1:
-    resolution: {integrity: sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==}
 
   brace-expansion@2.1.1:
     resolution: {integrity: sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==}
@@ -4088,7 +4085,7 @@ packages:
     resolution: {integrity: sha512-yB5CNFa14MbPJcomwNh3wLThtkZgcNyI2bNMRt8iE5Z8Vwl7f8vQXFAzn2HDOJvtDq2NTZBUGMSUNNyrv3/+cw==}
     engines: {node: '>= 12.13.0'}
     peerDependencies:
-      webpack: ^5.0.0
+      webpack: 5.107.2
 
   css-prefers-color-scheme@6.0.3:
     resolution: {integrity: sha512-4BqMbZksRkJQx2zAjrokiGMd07RqOa2IxIrrN10lyBe9xhn9DEvjUK79J6jkeiv9D9hQFXKb6g1jwU62jziJZA==}
@@ -4716,8 +4713,8 @@ packages:
   es-iterator-helpers@1.0.15:
     resolution: {integrity: sha512-GhoY8uYqd6iwUl2kgjTm4CZAf6oo5mHK7BPqx3rKgx893YSsy0LGHV6gfqqQvZt/8xM8xeOnfXBCfqclMKkJ5g==}
 
-  es-module-lexer@1.7.0:
-    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+  es-module-lexer@2.1.0:
+    resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
 
   es-object-atoms@1.1.2:
     resolution: {integrity: sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==}
@@ -5167,7 +5164,7 @@ packages:
     engines: {node: '>=12.13.0', yarn: '>=1.0.0'}
     peerDependencies:
       typescript: '>3.6.0'
-      webpack: ^5.11.0
+      webpack: 5.107.2
 
   form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
@@ -5538,7 +5535,7 @@ packages:
     resolution: {integrity: sha512-sy88PC2cRTVxvETRgUHFrL4No3UxvcH8G1NepGhqaTT+GXN2kTamqasot0inS5hXeg1cMbFDt27zzo9p35lZVw==}
     engines: {node: '>=10.13.0'}
     peerDependencies:
-      webpack: ^5.20.0
+      webpack: 5.107.2
 
   html2canvas@1.4.1:
     resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
@@ -6256,12 +6253,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@3.14.1:
-    resolution: {integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==}
-    hasBin: true
-
-  js-yaml@4.1.0:
-    resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
+  js-yaml@3.14.2:
+    resolution: {integrity: sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==}
     hasBin: true
 
   js-yaml@4.2.0:
@@ -6354,7 +6347,7 @@ packages:
     engines: {node: '>= 14.15.0'}
     peerDependencies:
       less: ^3.5.0 || ^4.0.0
-      webpack: ^5.0.0
+      webpack: 5.107.2
 
   less-loader@12.3.3:
     resolution: {integrity: sha512-F0+ErFFDj3Pt+nVrCN6VlEGEzocv9s7x/aR9v2riI+WM83UAfTYBDBjGPJnT55lBLR6JSI4fmWblt+aA2JN6/w==}
@@ -6362,7 +6355,7 @@ packages:
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       less: ^3.5.0 || ^4.0.0
-      webpack: ^5.0.0
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -6700,14 +6693,11 @@ packages:
   minimalistic-crypto-utils@1.0.1:
     resolution: {integrity: sha512-JIYlbt6g8i5jKfJ3xz7rF0LXmv2TkDxBLUkiBeZ7bAx4GnnNMr8xFpGnOxn6GhTEHx3SjRrZEoU+j04prX1ktg==}
 
-  minimatch@3.1.2:
-    resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
+  minimatch@3.1.4:
+    resolution: {integrity: sha512-twmL+S8+7yIsE9wsqgzU3E8/LumN3M3QELrBZ20OdmQ9jB2JvW5oZtBEmft84k/Gs5CG9mqtWc6Y9vW+JEzGxw==}
 
-  minimatch@3.1.5:
-    resolution: {integrity: sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==}
-
-  minimatch@8.0.4:
-    resolution: {integrity: sha512-W0Wvr9HyFXZRGIDgCicunpQ299OKXs9RgZfaukz4qAW/pJhcpUfupc9c+OObPOFueNy8VSrZgEmDtk6Kh4WzDA==}
+  minimatch@8.0.6:
+    resolution: {integrity: sha512-JVNTX5Qc03lB0PuFDuUcVTbi8u5kKchLXDYEnLJrOosZW8cqamFiyItG/7cn0QEt7XmeFHSLJRYg4KujJKuqlw==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minimatch@9.0.9:
@@ -7349,7 +7339,7 @@ packages:
     peerDependencies:
       '@rspack/core': 0.x || ^1.0.0 || ^2.0.0-0
       postcss: 8.5.15
-      webpack: ^5.0.0
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -8680,7 +8670,7 @@ packages:
       node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
       sass: ^1.3.0
       sass-embedded: '*'
-      webpack: ^5.0.0
+      webpack: 5.107.2
     peerDependenciesMeta:
       fibers:
         optional: true
@@ -8699,7 +8689,7 @@ packages:
       node-sass: ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0 || ^9.0.0
       sass: ^1.3.0
       sass-embedded: '*'
-      webpack: ^5.0.0
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@rspack/core':
         optional: true
@@ -9317,7 +9307,7 @@ packages:
       lightningcss: '*'
       postcss: '*'
       uglify-js: '*'
-      webpack: ^5.1.0
+      webpack: 5.107.2
     peerDependenciesMeta:
       '@minify-html/node':
         optional: true
@@ -9827,8 +9817,8 @@ packages:
     resolution: {integrity: sha512-HPuy+uuoTCaaoEoI1LQ3JN9+vrPBvEesnnX1jADHy728cHSMlq4wUc4afYqahq2B1mhQVZxCXOkNTnXltr+2vQ==}
     engines: {node: '>=10.13.0'}
 
-  webpack@5.89.0:
-    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
+  webpack@5.107.2:
+    resolution: {integrity: sha512-v7RhXaJbpMlV0D7hC7lb2EbnxkoeUqf9qhKr6lozx3Q48pmFrqqNRmZFUEGmi7pSwm6fCQ2H1IjvCkHqdpVdjQ==}
     engines: {node: '>=10.13.0'}
     hasBin: true
     peerDependencies:
@@ -12228,8 +12218,8 @@ snapshots:
       globals: 13.23.0
       ignore: 4.0.6
       import-fresh: 3.3.0
-      js-yaml: 3.14.1
-      minimatch: 3.1.2
+      js-yaml: 3.14.2
+      minimatch: 3.1.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12242,8 +12232,8 @@ snapshots:
       globals: 13.23.0
       ignore: 5.3.0
       import-fresh: 3.3.0
-      js-yaml: 4.1.0
-      minimatch: 3.1.2
+      js-yaml: 4.2.0
+      minimatch: 3.1.4
       strip-json-comments: 3.1.1
     transitivePeerDependencies:
       - supports-color
@@ -12315,7 +12305,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.1
       debug: 4.3.4
-      minimatch: 3.1.2
+      minimatch: 3.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12323,7 +12313,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
       debug: 4.4.3
-      minimatch: 3.1.5
+      minimatch: 3.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12331,7 +12321,7 @@ snapshots:
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
       debug: 4.3.4
-      minimatch: 3.1.2
+      minimatch: 3.1.4
     transitivePeerDependencies:
       - supports-color
 
@@ -12370,7 +12360,7 @@ snapshots:
       camelcase: 5.3.1
       find-up: 4.1.0
       get-package-type: 0.1.0
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       resolve-from: 5.0.0
 
   '@istanbuljs/schema@0.1.3': {}
@@ -12815,7 +12805,7 @@ snapshots:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
 
-  '@remix-run/router@1.13.1': {}
+  '@remix-run/router@1.23.3': {}
 
   '@scarf/scarf@1.4.0': {}
 
@@ -13099,19 +13089,9 @@ snapshots:
 
   '@types/d3-timer@3.0.2': {}
 
-  '@types/eslint-scope@3.7.7':
-    dependencies:
-      '@types/eslint': 9.6.1
-      '@types/estree': 1.0.9
-
   '@types/eslint@7.29.0':
     dependencies:
       '@types/estree': 1.0.5
-      '@types/json-schema': 7.0.15
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.9
       '@types/json-schema': 7.0.15
 
   '@types/estree@1.0.5': {}
@@ -13577,10 +13557,10 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/bundler-mako@0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/bundler-mako@0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@umijs/bundler-utils': 4.6.61
-      '@umijs/mako': 0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/mako': 0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       chalk: 4.1.2
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
@@ -13631,22 +13611,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@umijs/bundler-utoopack@4.6.61(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/bundler-utoopack@4.6.61(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@umijs/bundler-utils': 4.6.61
-      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
-      '@utoo/pack': 1.4.12(less-loader@11.1.0(less@4.1.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
+      '@utoo/pack': 1.4.12(less-loader@11.1.0(less@4.1.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))
       compression: 1.8.1
       connect-history-api-fallback: 2.0.0
       cors: 2.8.6
       express: 4.22.2
       express-http-proxy: 2.1.2
       less: 4.1.3
-      less-loader: 11.1.0(less@4.1.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      less-loader: 11.1.0(less@4.1.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       postcss: 8.5.15
       resolve-url-loader: 5.0.0
       sass: 1.54.0
-      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@types/webpack'
       - bufferutil
@@ -13687,7 +13667,7 @@ snapshots:
       - supports-color
       - terser
 
-  '@umijs/bundler-webpack@4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/bundler-webpack@4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@svgr/core': 6.5.1
       '@svgr/plugin-jsx': 6.5.1(@svgr/core@6.5.1)
@@ -13697,12 +13677,12 @@ snapshots:
       '@umijs/bundler-utils': 4.6.61
       '@umijs/case-sensitive-paths-webpack-plugin': 1.0.1
       '@umijs/mfsu': 4.6.61
-      '@umijs/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@0.21.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/react-refresh-webpack-plugin': 0.5.11(react-refresh@0.14.0)(type-fest@0.21.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/utils': 4.6.61
       cors: 2.8.6
-      css-loader: 6.7.1(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      css-loader: 6.7.1(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       es5-imcompatible-versions: 0.1.90
-      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      fork-ts-checker-webpack-plugin: 8.0.0(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       jest-worker: 29.4.3
       lightningcss: 1.22.1
       node-libs-browser: 2.2.1
@@ -13889,7 +13869,7 @@ snapshots:
   '@umijs/mako-win32-x64-msvc@0.11.10':
     optional: true
 
-  '@umijs/mako@0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/mako@0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@module-federation/webpack-bundler-runtime': 0.8.12
       '@swc/helpers': 0.5.1
@@ -13897,17 +13877,17 @@ snapshots:
       chalk: 4.1.2
       enhanced-resolve: 5.23.0
       less: 4.6.4
-      less-loader: 12.3.3(less@4.6.4)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      less-loader: 12.3.3(less@4.6.4)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       loader-runner: 4.3.2
       loader-utils: 3.3.1
       lodash: 4.18.1
       node-libs-browser-okam: 2.2.5
       piscina: 4.9.2
-      postcss-loader: 8.2.1(postcss@8.5.15)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      postcss-loader: 8.2.1(postcss@8.5.15)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       react-error-overlay: 6.0.9
       react-refresh: 0.14.2
       resolve: 1.22.12
-      sass-loader: 16.0.8(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      sass-loader: 16.0.8(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       semver: 7.8.3
       yargs-parser: 21.1.1
     optionalDependencies:
@@ -13941,14 +13921,14 @@ snapshots:
       - postcss-markdown
       - supports-color
 
-  '@umijs/max@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react-dom@18.2.17)(@types/react@18.2.41)(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/max@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react-dom@18.2.17)(@types/react@18.2.41)(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@umijs/lint': 4.6.61(eslint@8.35.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(stylelint@14.8.2)(typescript@4.9.5)
       '@umijs/plugins': 4.6.61(@babel/core@7.23.5)(@types/react-dom@18.2.17)(@types/react@18.2.41)(antd@4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       antd: 4.24.16(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       eslint: 8.35.0
       stylelint: 14.8.2
-      umi: 4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.35.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@14.8.2)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      umi: 4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.35.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@14.8.2)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
     transitivePeerDependencies:
       - '@babel/core'
       - '@rspack/core'
@@ -14169,7 +14149,7 @@ snapshots:
       - react-native
       - supports-color
 
-  '@umijs/preset-umi@4.6.61(@types/node@20.10.3)(@types/react@18.2.41)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/preset-umi@4.6.61(@types/node@20.10.3)(@types/react@18.2.41)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       '@iconify/utils': 2.1.1
       '@stagewise/toolbar': 0.6.2
@@ -14177,11 +14157,11 @@ snapshots:
       '@umijs/ast': 4.6.61
       '@umijs/babel-preset-umi': 4.6.61
       '@umijs/bundler-esbuild': 4.6.61
-      '@umijs/bundler-mako': 0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/bundler-mako': 0.11.10(postcss@8.5.15)(sass@1.54.0)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/bundler-utils': 4.6.61
-      '@umijs/bundler-utoopack': 4.6.61(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/bundler-utoopack': 4.6.61(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/bundler-vite': 4.6.61(@types/node@20.10.3)(lightningcss@1.22.1)(postcss@8.5.15)(rollup@3.30.0)(sass@1.54.0)(sugarss@2.0.0)(terser@5.48.0)
-      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/core': 4.6.61
       '@umijs/did-you-know': 1.0.4
       '@umijs/es-module-parser': 0.0.7
@@ -14200,7 +14180,7 @@ snapshots:
       current-script-polyfill: 1.0.0
       enhanced-resolve: 5.9.3
       fast-glob: 3.2.12
-      html-webpack-plugin: 5.5.0(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      html-webpack-plugin: 5.5.0(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       less-plugin-resolve: 1.0.2
       path-to-regexp: 1.7.0
       postcss: 8.5.15
@@ -14236,7 +14216,7 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  '@umijs/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@0.21.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))':
+  '@umijs/react-refresh-webpack-plugin@0.5.11(react-refresh@0.14.0)(type-fest@0.21.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))':
     dependencies:
       ansi-html-community: 0.0.8
       common-path-prefix: 3.0.0
@@ -14248,7 +14228,7 @@ snapshots:
       react-refresh: 0.14.0
       schema-utils: 3.3.0
       source-map: 0.7.6
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
     optionalDependencies:
       type-fest: 0.21.3
 
@@ -14272,13 +14252,13 @@ snapshots:
       react-helmet-async: 1.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       react-router-dom: 6.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
 
-  '@umijs/request-record@1.1.4(umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)))':
+  '@umijs/request-record@1.1.4(umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)))':
     dependencies:
       chokidar: 3.5.3
       express: 4.22.2
       lodash: 4.18.1
       prettier: 2.8.8
-      umi: 4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      umi: 4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
     transitivePeerDependencies:
       - supports-color
 
@@ -14379,7 +14359,7 @@ snapshots:
   '@utoo/pack-win32-x64-msvc@1.4.12':
     optional: true
 
-  '@utoo/pack@1.4.12(less-loader@11.1.0(less@4.1.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))':
+  '@utoo/pack@1.4.12(less-loader@11.1.0(less@4.1.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)))(less@4.1.3)(postcss@8.5.15)(resolve-url-loader@5.0.0)(sass-loader@13.2.0(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)))(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))':
     dependencies:
       '@babel/code-frame': 7.22.5
       '@hono/node-server': 1.19.14(hono@4.12.24)
@@ -14391,13 +14371,13 @@ snapshots:
       get-port: 5.1.1
       hono: 4.12.24
       less: 4.1.3
-      less-loader: 11.1.0(less@4.1.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      less-loader: 11.1.0(less@4.1.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       nanoid: 3.3.12
       picocolors: 1.1.1
       postcss: 8.5.15
       resolve-url-loader: 5.0.0
       sass: 1.54.0
-      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      sass-loader: 13.2.0(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       semver: 7.8.3
       send: 0.17.1
       styled-jsx: 5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0)
@@ -14519,7 +14499,7 @@ snapshots:
       acorn: 8.11.2
       acorn-walk: 8.3.0
 
-  acorn-import-assertions@1.9.0(acorn@8.16.0):
+  acorn-import-phases@1.0.4(acorn@8.16.0):
     dependencies:
       acorn: 8.16.0
 
@@ -15100,19 +15080,10 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@1.1.11:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
   brace-expansion@1.1.15:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-
-  brace-expansion@2.0.1:
-    dependencies:
-      balanced-match: 1.0.2
 
   brace-expansion@2.1.1:
     dependencies:
@@ -15645,7 +15616,7 @@ snapshots:
     dependencies:
       utrie: 1.0.2
 
-  css-loader@6.7.1(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  css-loader@6.7.1(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
       postcss: 8.5.15
@@ -15655,7 +15626,7 @@ snapshots:
       postcss-modules-values: 4.0.0(postcss@8.5.15)
       postcss-value-parser: 4.2.0
       semver: 7.8.3
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
   css-prefers-color-scheme@6.0.3(postcss@8.5.15):
     dependencies:
@@ -16379,7 +16350,7 @@ snapshots:
       iterator.prototype: 1.1.2
       safe-array-concat: 1.0.1
 
-  es-module-lexer@1.7.0: {}
+  es-module-lexer@2.1.0: {}
 
   es-object-atoms@1.1.2:
     dependencies:
@@ -16623,7 +16594,7 @@ snapshots:
       eslint: 7.32.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       object.entries: 1.1.7
       object.fromentries: 2.0.7
       object.hasown: 1.1.3
@@ -16643,7 +16614,7 @@ snapshots:
       eslint: 8.35.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       object.entries: 1.1.7
       object.fromentries: 2.0.7
       object.hasown: 1.1.3
@@ -16663,7 +16634,7 @@ snapshots:
       eslint: 8.55.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.5
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       object.entries: 1.1.7
       object.fromentries: 2.0.7
       object.hasown: 1.1.3
@@ -16764,11 +16735,11 @@ snapshots:
       import-fresh: 3.3.0
       imurmurhash: 0.1.4
       is-glob: 4.0.3
-      js-yaml: 3.14.1
+      js-yaml: 3.14.2
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       natural-compare: 1.4.0
       optionator: 0.9.3
       progress: 2.0.3
@@ -16817,7 +16788,7 @@ snapshots:
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.5
+      minimatch: 3.1.4
       natural-compare: 1.4.0
       optionator: 0.9.4
       regexpp: 3.2.0
@@ -16858,11 +16829,11 @@ snapshots:
       imurmurhash: 0.1.4
       is-glob: 4.0.3
       is-path-inside: 3.0.3
-      js-yaml: 4.1.0
+      js-yaml: 4.2.0
       json-stable-stringify-without-jsonify: 1.0.1
       levn: 0.4.1
       lodash.merge: 4.6.2
-      minimatch: 3.1.2
+      minimatch: 3.1.4
       natural-compare: 1.4.0
       optionator: 0.9.3
       strip-ansi: 6.0.1
@@ -17164,7 +17135,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  fork-ts-checker-webpack-plugin@8.0.0(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  fork-ts-checker-webpack-plugin@8.0.0(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@babel/code-frame': 7.29.7
       chalk: 4.1.2
@@ -17173,13 +17144,13 @@ snapshots:
       deepmerge: 4.3.1
       fs-extra: 10.1.0
       memfs: 3.5.3
-      minimatch: 3.1.5
+      minimatch: 3.1.4
       node-abort-controller: 3.1.1
       schema-utils: 3.3.0
       semver: 7.8.3
       tapable: 2.3.3
       typescript: 4.9.5
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
   form-data@4.0.0:
     dependencies:
@@ -17355,14 +17326,14 @@ snapshots:
       fs.realpath: 1.0.0
       inflight: 1.0.6
       inherits: 2.0.4
-      minimatch: 3.1.5
+      minimatch: 3.1.4
       once: 1.4.0
       path-is-absolute: 1.0.1
 
   glob@9.3.5:
     dependencies:
       fs.realpath: 1.0.0
-      minimatch: 8.0.4
+      minimatch: 8.0.6
       minipass: 4.2.8
       path-scurry: 1.10.1
 
@@ -17579,14 +17550,14 @@ snapshots:
 
   html-tags@3.3.1: {}
 
-  html-webpack-plugin@5.5.0(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  html-webpack-plugin@5.5.0(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@types/html-minifier-terser': 6.1.0
       html-minifier-terser: 6.1.0
       lodash: 4.18.1
       pretty-error: 4.0.0
       tapable: 2.3.3
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
   html2canvas@1.4.1:
     dependencies:
@@ -18486,14 +18457,10 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@3.14.1:
+  js-yaml@3.14.2:
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
-
-  js-yaml@4.1.0:
-    dependencies:
-      argparse: 2.0.1
 
   js-yaml@4.2.0:
     dependencies:
@@ -18587,17 +18554,17 @@ snapshots:
     dependencies:
       invert-kv: 3.0.1
 
-  less-loader@11.1.0(less@4.1.3)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  less-loader@11.1.0(less@4.1.3)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       klona: 2.0.6
       less: 4.1.3
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
-  less-loader@12.3.3(less@4.6.4)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  less-loader@12.3.3(less@4.6.4)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       less: 4.6.4
     optionalDependencies:
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
   less-plugin-resolve@1.0.2:
     dependencies:
@@ -18947,17 +18914,13 @@ snapshots:
 
   minimalistic-crypto-utils@1.0.1: {}
 
-  minimatch@3.1.2:
-    dependencies:
-      brace-expansion: 1.1.11
-
-  minimatch@3.1.5:
+  minimatch@3.1.4:
     dependencies:
       brace-expansion: 1.1.15
 
-  minimatch@8.0.4:
+  minimatch@8.0.6:
     dependencies:
-      brace-expansion: 2.0.1
+      brace-expansion: 2.1.1
 
   minimatch@9.0.9:
     dependencies:
@@ -19642,14 +19605,14 @@ snapshots:
     dependencies:
       postcss: 8.5.15
 
-  postcss-loader@8.2.1(postcss@8.5.15)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  postcss-loader@8.2.1(postcss@8.5.15)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       cosmiconfig: 9.0.2(typescript@4.9.5)
       jiti: 2.7.0
       postcss: 8.5.15
       semver: 7.8.3
     optionalDependencies:
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
     transitivePeerDependencies:
       - typescript
 
@@ -20890,7 +20853,7 @@ snapshots:
 
   react-router-dom@6.20.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0):
     dependencies:
-      '@remix-run/router': 1.13.1
+      '@remix-run/router': 1.23.3
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       react-router: 6.20.1(react@18.2.0)
@@ -20929,7 +20892,7 @@ snapshots:
 
   react-router@6.20.1(react@18.2.0):
     dependencies:
-      '@remix-run/router': 1.13.1
+      '@remix-run/router': 1.23.3
       react: 18.2.0
 
   react-router@6.3.0(react@18.2.0):
@@ -21398,20 +21361,20 @@ snapshots:
 
   safer-buffer@2.1.2: {}
 
-  sass-loader@13.2.0(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  sass-loader@13.2.0(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       klona: 2.0.6
       neo-async: 2.6.2
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
     optionalDependencies:
       sass: 1.54.0
 
-  sass-loader@16.0.8(sass@1.54.0)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  sass-loader@16.0.8(sass@1.54.0)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       neo-async: 2.6.2
     optionalDependencies:
       sass: 1.54.0
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
 
   sass@1.54.0:
     dependencies:
@@ -22219,13 +22182,13 @@ snapshots:
 
   tapable@2.3.3: {}
 
-  terser-webpack-plugin@5.6.1(lightningcss@1.22.1)(postcss@8.5.15)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  terser-webpack-plugin@5.6.1(lightningcss@1.22.1)(postcss@8.5.15)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@jridgewell/trace-mapping': 0.3.31
       jest-worker: 27.5.1
       schema-utils: 4.3.3
       terser: 5.48.0
-      webpack: 5.89.0(lightningcss@1.22.1)(postcss@8.5.15)
+      webpack: 5.107.2(lightningcss@1.22.1)(postcss@8.5.15)
     optionalDependencies:
       lightningcss: 1.22.1
       postcss: 8.5.15
@@ -22241,7 +22204,7 @@ snapshots:
     dependencies:
       '@istanbuljs/schema': 0.1.3
       glob: 7.2.3
-      minimatch: 3.1.2
+      minimatch: 3.1.4
 
   text-segmentation@1.0.3:
     dependencies:
@@ -22455,12 +22418,12 @@ snapshots:
 
   ua-parser-js@0.7.37: {}
 
-  umi-presets-pro@2.0.3(kea5y674igzsfvf4iconbttr7e):
+  umi-presets-pro@2.0.3(5pzn2vysq3bk52aie2jkmolqri):
     dependencies:
       '@alita/plugins': 3.3.7(@types/react-dom@18.2.17)(@types/react@18.2.41)(antd@5.12.1(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(babel-plugin-styled-components@2.1.4(@babel/core@7.23.5)(styled-components@6.1.1(react-dom@18.2.0(react@18.2.0))(react@18.2.0)))(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@umijs/max-plugin-openapi': 2.0.3(chokidar@3.6.0)(encoding@0.1.13)
       '@umijs/plugins': 4.0.89(@babel/core@7.23.5)(@types/react-dom@18.2.17)(@types/react@18.2.41)(antd@5.12.1(date-fns@2.30.0)(moment@2.29.4)(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(dva@2.5.0-beta.2(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(rc-field-form@1.41.0(react-dom@18.2.0(react@18.2.0))(react@18.2.0))(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
-      '@umijs/request-record': 1.1.4(umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)))
+      '@umijs/request-record': 1.1.4(umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)))
       swagger-ui-dist: 4.19.1
     transitivePeerDependencies:
       - '@babel/core'
@@ -22487,14 +22450,14 @@ snapshots:
       isomorphic-fetch: 2.2.1
       qs: 6.15.2
 
-  umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.35.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@14.8.2)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.35.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@14.8.2)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@babel/runtime': 7.23.6
       '@umijs/bundler-utils': 4.6.61
-      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/core': 4.6.61
       '@umijs/lint': 4.6.61(eslint@8.35.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(stylelint@14.8.2)(typescript@4.9.5)
-      '@umijs/preset-umi': 4.6.61(@types/node@20.10.3)(@types/react@18.2.41)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/preset-umi': 4.6.61(@types/node@20.10.3)(@types/react@18.2.41)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/renderer-react': 4.6.61(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@umijs/server': 4.6.61
       '@umijs/test': 4.6.61(@babel/core@7.23.5)
@@ -22541,14 +22504,14 @@ snapshots:
       - webpack-hot-middleware
       - webpack-plugin-serve
 
-  umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15)):
+  umi@4.6.61(@babel/core@7.23.5)(@types/node@20.10.3)(@types/react@18.2.41)(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(lightningcss@1.22.1)(prettier@2.8.8)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(stylelint@13.13.1)(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15)):
     dependencies:
       '@babel/runtime': 7.23.6
       '@umijs/bundler-utils': 4.6.61
-      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/bundler-webpack': 4.6.61(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/core': 4.6.61
       '@umijs/lint': 4.6.61(eslint@8.55.0)(jest@29.7.0(@types/node@20.10.3)(babel-plugin-macros@3.1.0)(ts-node@10.9.1(@types/node@20.10.3)(typescript@4.9.5)))(stylelint@13.13.1)(typescript@4.9.5)
-      '@umijs/preset-umi': 4.6.61(@types/node@20.10.3)(@types/react@18.2.41)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      '@umijs/preset-umi': 4.6.61(@types/node@20.10.3)(@types/react@18.2.41)(lightningcss@1.22.1)(rollup@3.30.0)(sass@1.54.0)(styled-jsx@5.1.7(@babel/core@7.23.5)(babel-plugin-macros@3.1.0)(react@18.2.0))(sugarss@2.0.0)(terser@5.48.0)(type-fest@0.21.3)(typescript@4.9.5)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       '@umijs/renderer-react': 4.6.61(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
       '@umijs/server': 4.6.61
       '@umijs/test': 4.6.61(@babel/core@7.23.5)
@@ -22827,30 +22790,29 @@ snapshots:
 
   webpack-sources@3.5.0: {}
 
-  webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15):
+  webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15):
     dependencies:
-      '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.9
+      '@types/json-schema': 7.0.15
       '@webassemblyjs/ast': 1.14.1
       '@webassemblyjs/wasm-edit': 1.14.1
       '@webassemblyjs/wasm-parser': 1.14.1
       acorn: 8.16.0
-      acorn-import-assertions: 1.9.0(acorn@8.16.0)
+      acorn-import-phases: 1.0.4(acorn@8.16.0)
       browserslist: 4.28.2
       chrome-trace-event: 1.0.4
       enhanced-resolve: 5.23.0
-      es-module-lexer: 1.7.0
+      es-module-lexer: 2.1.0
       eslint-scope: 5.1.1
       events: 3.3.0
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
       loader-runner: 4.3.2
-      mime-types: 2.1.35
+      mime-db: 1.54.0
       neo-async: 2.6.2
-      schema-utils: 3.3.0
+      schema-utils: 4.3.3
       tapable: 2.3.3
-      terser-webpack-plugin: 5.6.1(lightningcss@1.22.1)(postcss@8.5.15)(webpack@5.89.0(lightningcss@1.22.1)(postcss@8.5.15))
+      terser-webpack-plugin: 5.6.1(lightningcss@1.22.1)(postcss@8.5.15)(webpack@5.107.2(lightningcss@1.22.1)(postcss@8.5.15))
       watchpack: 2.5.1
       webpack-sources: 3.5.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary
- pin webpack 5.107.2 explicitly for the Umi 4 webpack peer chain
- add targeted pnpm overrides for @remix-run/router, js-yaml, and minimatch security-update dead ends
- refresh pnpm-lock.yaml after the dependency convergence

## Tests
- pnpm install
- pnpm audit target check for @remix-run/router, webpack, js-yaml, minimatch, @babel/plugin-transform-modules-systemjs, @tootallnate/once, picomatch, postcss, yaml, flatted, immutable, lodash, tar, shell-quote, yeoman-environment
- pnpm test -- --runInBand src/util/requestError.test.ts
- pnpm tsc
- pnpm lint:js
- pnpm build:local

## Docs
- No user-facing docs changed.
- AI memory will be updated in mss-boot-docs after this security pass is merged.

## Security
- Clears the Dependabot security-update failures observed after #108 for @remix-run/router, webpack, js-yaml, and minimatch.
- The remaining advisories are broader legacy stack issues and should be handled in a separate dependency-convergence round.

## Release
- No Cloudflare deploy. No runtime feature change expected beyond dependency resolution.