### PR TITLE
fix(admin): restore standalone first paint

### DIFF
--- a/aigc/prompts/admin-beta-first-screen-2026-06-11.zh-CN.md
+++ b/aigc/prompts/admin-beta-first-screen-2026-06-11.zh-CN.md
@@ -1,0 +1,37 @@
+# admin beta 首屏白屏与慢启动修复记忆
+
+## 背景
+
+- 时间：2026-06-11。
+- 环境：`admin-beta.mss-boot-io.top` Cloudflare beta 前端，对应 `admin-api-beta.mss-boot-io.top`。
+- 现象：访问 beta 根路径时页面白屏，控制台有 `single-spa minified message #1`；首屏等待时间很长。
+
+## 根因
+
+- `config/config.ts` 默认启用了 `qiankun: { master: {} }`，导致 standalone Cloudflare 前端以 qiankun master 模式构建。
+- 线上 HTML 挂载点为 `#root-master`，而普通 standalone 应用应挂载 `#root`，因此 beta/prod 这类独立前端不应默认启用 qiankun master。
+- 未登录首屏的 `getInitialState` 会先串行请求语言、应用配置、用户配置，再跳转登录页；当 beta API 慢或异常时，未登录用户会长时间看到空白壳。
+
+## 修复策略
+
+- 移除默认 qiankun master 配置，让 standalone 构建回到 `#root`。
+- 未登录用户在 `getInitialState` 中立即进入 `/user/login?redirect=...`，不再阻塞等待语言、应用配置、用户配置 API。
+- 登录页异步补拉公共应用配置，用于 logo、站点名、第三方登录开关等展示，不阻塞首屏可见内容。
+- 清理登录页嵌套 `<a>` DOM，减少测试和浏览器控制台噪音。
+
+## 验证记录
+
+- `pnpm install --frozen-lockfile`
+- `pnpm tsc`
+- `pnpm lint:js`
+- `pnpm test -- --runInBand`
+- `pnpm build:beta`
+- `pnpm build:local`
+- 本地 beta 静态冒烟：`/` 能进入 `/user/login?redirect=%2Fworkplace`，登录表单可见，HTML 使用 `#root`，不存在 `#root-master`。
+- 构建产物扫描：主 bundle 不再包含 `single-spa` 和 `registerApplication`，`root-master` 为 false。
+
+## 仍需跟进
+
+- 2026-06-11 本机直连 `admin-api-beta.mss-boot-io.top` 返回 Cloudflare 522 或超时。
+- 同时 `kubectl --kubeconfig ~/.kube/baas.yaml` 访问集群 API 出现 TLS handshake timeout。
+- 因此 beta API 源站连通性是独立问题；待集群 API 可达后，优先检查 `mss-boot-beta` namespace 的 Pod、Service、Ingress、Cloudflare DNS/源站回源链路。

--- a/config/config.ts
+++ b/config/config.ts
@@ -149,7 +149,4 @@ export default defineConfig({
   define: {
     API_URL: '',
   },
-  qiankun: {
-    master: {},
-  },
 });

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -29,6 +29,14 @@ const excludePath = [
   '/user/callback/lark',
 ];
 
+const getAuthRedirect = (location: { pathname: string; search: string; hash: string }) => {
+  const redirect =
+    location.pathname === '/'
+      ? '/workplace'
+      : `${location.pathname}${location.search}${location.hash}`;
+  return `${loginPath}?redirect=${encodeURIComponent(redirect)}`;
+};
+
 /**
  * @see  https://umijs.org/zh-CN/plugins/plugin-initial-state
  * */
@@ -40,7 +48,32 @@ export async function getInitialState(): Promise<{
   loading?: boolean;
   fetchUserInfo?: () => Promise<API.User | undefined>;
 }> {
-  // load language
+  const fetchUserInfo = async () => {
+    try {
+      return await getUserUserInfo({
+        skipErrorHandler: true,
+      });
+    } catch (error) {
+      history.push(loginPath);
+    }
+    return undefined;
+  };
+
+  const { location } = history;
+  const token = localStorage.getItem('token');
+  const isLoginPage = location.pathname === loginPath || excludePath.includes(location.pathname);
+
+  if (!token) {
+    if (!isLoginPage) {
+      history.replace(getAuthRedirect(location));
+    }
+    return {
+      fetchUserInfo,
+      settings: defaultSettings as Partial<LayoutSettings>,
+    };
+  }
+
+  // load language after auth is known so public first paint is not blocked by API calls
   let languageData;
   try {
     languageData = await getLanguages({ pageSize: 999 });
@@ -64,18 +97,7 @@ export async function getInitialState(): Promise<{
       });
     });
   }
-  const fetchUserInfo = async () => {
-    try {
-      return await getUserUserInfo({
-        skipErrorHandler: true,
-      });
-    } catch (error) {
-      history.push(loginPath);
-    }
-    return undefined;
-  };
 
-  const { location } = history;
   let appConfig, userConfig;
   try {
     appConfig = await getAppConfigsProfile({ skipErrorHandler: true });
@@ -107,9 +129,6 @@ export async function getInitialState(): Promise<{
     appConfig?.theme?.colorPrimary ||
     defaultSettings.colorPrimary;
   // defaultSettings.splitMenus = userConfig?.theme?.splitMenus || appConfig?.theme?.splitMenus || defaultSettings.splitMenus;
-
-  const token = localStorage.getItem('token');
-  const isLoginPage = location.pathname === loginPath || excludePath.includes(location.pathname);
 
   if (token && !isLoginPage) {
     try {
@@ -177,7 +196,7 @@ export const layout: RunTimeLayoutConfig = ({ initialState, setInitialState }) =
       const { location } = history;
       const token = localStorage.getItem('token');
       if (!initialState?.currentUser && !token && location.pathname !== loginPath) {
-        history.push(loginPath);
+        history.replace(getAuthRedirect(location));
       }
     },
     layoutBgImgList: [

--- a/src/pages/User/Login/__snapshots__/login.test.tsx.snap
+++ b/src/pages/User/Login/__snapshots__/login.test.tsx.snap
@@ -357,8 +357,6 @@ exports[`Login Page should show login form 1`] = `
               </label>
               <a
                 href="/user/forget"
-              />
-              <a
                 style="float: right;"
               >
                 Forgot Password ?

--- a/src/pages/User/Login/index.tsx
+++ b/src/pages/User/Login/index.tsx
@@ -23,6 +23,7 @@ import Settings from '../../../../config/defaultSettings';
 import { useRequest } from 'ahooks';
 import { LarkOutlined } from '@/components/MssBoot/icon';
 import { resolveSafeRedirect } from './redirect';
+import { getAppConfigsProfile } from '@/services/admin/appConfig';
 
 function randToken(): string {
   let result = '';
@@ -172,6 +173,27 @@ const Login: React.FC = () => {
       backgroundSize: '100% 100%',
     };
   });
+
+  useEffect(() => {
+    if (initialState?.appConfig) {
+      return;
+    }
+    let disposed = false;
+    getAppConfigsProfile({ skipErrorHandler: true })
+      .then((appConfig) => {
+        if (disposed || !appConfig) {
+          return;
+        }
+        setInitialState((state) => ({
+          ...state,
+          appConfig,
+        }));
+      })
+      .catch(() => {});
+    return () => {
+      disposed = true;
+    };
+  }, [initialState?.appConfig, setInitialState]);
 
   const fetchUserInfo = async () => {
     const userInfo = await initialState?.fetchUserInfo?.();
@@ -353,11 +375,19 @@ const Login: React.FC = () => {
             initialState?.appConfig?.security?.registerEnabled ? (
               <p>
                 还没有账号? &nbsp;
-                <Link to="/user/register">
-                  <a>
-                    <FormattedMessage id="pages.login.signup" defaultMessage="注册账户" />
-                  </a>
-                </Link>
+                <span
+                  role="link"
+                  tabIndex={0}
+                  style={{ color: '#1677ff', cursor: 'pointer' }}
+                  onClick={() => history.push('/user/register')}
+                  onKeyDown={(event) => {
+                    if (event.key === 'Enter' || event.key === ' ') {
+                      history.push('/user/register');
+                    }
+                  }}
+                >
+                  <FormattedMessage id="pages.login.signup" defaultMessage="注册账户" />
+                </span>
               </p>
             ) : (
               ''
@@ -591,14 +621,13 @@ const Login: React.FC = () => {
               <FormattedMessage id="pages.login.rememberMe" defaultMessage="自动登录" />
             </ProFormCheckbox>
 
-            <Link to="/user/forget">
-              <a
-                style={{
-                  float: 'right',
-                }}
-              >
-                <FormattedMessage id="pages.login.forgotPassword" defaultMessage="忘记密码" />
-              </a>
+            <Link
+              to="/user/forget"
+              style={{
+                float: 'right',
+              }}
+            >
+              <FormattedMessage id="pages.login.forgotPassword" defaultMessage="忘记密码" />
             </Link>
           </div>
         </LoginForm>


### PR DESCRIPTION
## Summary
- disable qiankun master mode for the standalone admin deployment so the app mounts on `#root` instead of `#root-master`
- avoid blocking unauthenticated first paint on language/app/user config API calls; redirect public entry to login immediately and hydrate public app config asynchronously
- remove nested anchor markup in the login form and update the snapshot
- add `aigc` memory for the beta first-screen incident and follow-up notes

## Tests / Validation
- `pnpm install --frozen-lockfile`
- `pnpm tsc`
- `pnpm lint:js`
- `pnpm test -- --runInBand`
- `pnpm build:beta`
- `pnpm build:local`
- local beta static smoke: `/` redirects to `/user/login?redirect=%2Fworkplace`, renders the login form, uses `#root`, and has no `root-master`/`single-spa`/`registerApplication` in the generated standalone bundle

## Docs Impact
- Added `aigc/prompts/admin-beta-first-screen-2026-06-11.zh-CN.md` with root cause, validation, and beta API follow-up memory.

## Security Impact
- No authentication or authorization contract changes.
- Login redirect remains same-origin/path based and continues to use existing `resolveSafeRedirect` handling after login.

## Release / Compatibility Impact
- Patch-level frontend release candidate for Cloudflare beta.
- No backend API contract or data migration changes.
- Rollback is safe by redeploying the previous Cloudflare Pages/Worker version if an unexpected frontend regression appears.

## Known Follow-up
- Direct beta API checks currently return Cloudflare 522 / timeout, and `kubectl --kubeconfig ~/.kube/baas.yaml` also hits TLS handshake timeout from this machine. That looks independent from the frontend white-screen fix and needs beta origin/cluster connectivity follow-up once the cluster API is reachable.
