### PR TITLE
fix(admin): avoid blank screen on stale token

### DIFF
--- a/aigc/prompts/admin-beta-first-screen-2026-06-11.zh-CN.md
+++ b/aigc/prompts/admin-beta-first-screen-2026-06-11.zh-CN.md
@@ -11,12 +11,15 @@
 - `config/config.ts` 默认启用了 `qiankun: { master: {} }`，导致 standalone Cloudflare 前端以 qiankun master 模式构建。
 - 线上 HTML 挂载点为 `#root-master`，而普通 standalone 应用应挂载 `#root`，因此 beta/prod 这类独立前端不应默认启用 qiankun master。
 - 未登录首屏的 `getInitialState` 会先串行请求语言、应用配置、用户配置，再跳转登录页；当 beta API 慢或异常时，未登录用户会长时间看到空白壳。
+- 已有 token 或 `autoLogin` 的浏览器会继续等待用户信息/刷新 token；当 beta API 522/超时时，登录页也可能因为刷新态返回空 Fragment，真实域名仍表现为空白。
 
 ## 修复策略
 
 - 移除默认 qiankun master 配置，让 standalone 构建回到 `#root`。
 - 未登录用户在 `getInitialState` 中立即进入 `/user/login?redirect=...`，不再阻塞等待语言、应用配置、用户配置 API。
+- 已有 token 的用户信息请求增加超时兜底；超时或失败时清理本地登录态并进入登录页。
 - 登录页异步补拉公共应用配置，用于 logo、站点名、第三方登录开关等展示，不阻塞首屏可见内容。
+- 登录页不再因为 `autoLogin` 刷新 token 请求处于 loading 状态而渲染空 Fragment，后端不可达时也应先展示可见表单。
 - 清理登录页嵌套 `<a>` DOM，减少测试和浏览器控制台噪音。
 
 ## 验证记录

--- a/src/app.tsx
+++ b/src/app.tsx
@@ -37,6 +37,21 @@ const getAuthRedirect = (location: { pathname: string; search: string; hash: str
   return `${loginPath}?redirect=${encodeURIComponent(redirect)}`;
 };
 
+const clearAuthState = () => {
+  localStorage.removeItem('token');
+  localStorage.removeItem('token.expire');
+  localStorage.removeItem('autoLogin');
+};
+
+const withTimeout = async <T,>(request: () => Promise<T>, timeoutMs = 4000) => {
+  return Promise.race<T | undefined>([
+    request().catch(() => undefined),
+    new Promise<undefined>((resolve) => {
+      setTimeout(() => resolve(undefined), timeoutMs);
+    }),
+  ]);
+};
+
 /**
  * @see  https://umijs.org/zh-CN/plugins/plugin-initial-state
  * */
@@ -49,21 +64,18 @@ export async function getInitialState(): Promise<{
   fetchUserInfo?: () => Promise<API.User | undefined>;
 }> {
   const fetchUserInfo = async () => {
-    try {
-      return await getUserUserInfo({
+    return withTimeout(() =>
+      getUserUserInfo({
         skipErrorHandler: true,
-      });
-    } catch (error) {
-      history.push(loginPath);
-    }
-    return undefined;
+      }),
+    );
   };
 
   const { location } = history;
   const token = localStorage.getItem('token');
   const isLoginPage = location.pathname === loginPath || excludePath.includes(location.pathname);
 
-  if (!token) {
+  if (!token || isLoginPage) {
     if (!isLoginPage) {
       history.replace(getAuthRedirect(location));
     }
@@ -73,10 +85,20 @@ export async function getInitialState(): Promise<{
     };
   }
 
+  const currentUser = await fetchUserInfo();
+  if (!currentUser) {
+    clearAuthState();
+    history.replace(getAuthRedirect(location));
+    return {
+      fetchUserInfo,
+      settings: defaultSettings as Partial<LayoutSettings>,
+    };
+  }
+
   // load language after auth is known so public first paint is not blocked by API calls
   let languageData;
   try {
-    languageData = await getLanguages({ pageSize: 999 });
+    languageData = await withTimeout(() => getLanguages({ pageSize: 999 }), 2500);
   } catch (e) {}
   if (languageData?.data) {
     languageData.data.forEach((item) => {
@@ -100,10 +122,10 @@ export async function getInitialState(): Promise<{
 
   let appConfig, userConfig;
   try {
-    appConfig = await getAppConfigsProfile({ skipErrorHandler: true });
+    appConfig = await withTimeout(() => getAppConfigsProfile({ skipErrorHandler: true }), 2500);
   } catch (e) {}
   try {
-    userConfig = await getUserConfigsProfile({ skipErrorHandler: true });
+    userConfig = await withTimeout(() => getUserConfigsProfile({ skipErrorHandler: true }), 2500);
   } catch (e) {}
   //set title
   defaultSettings.title = appConfig?.base?.websiteName || 'mss-boot-admin';
@@ -132,7 +154,6 @@ export async function getInitialState(): Promise<{
 
   if (token && !isLoginPage) {
     try {
-      const currentUser = await fetchUserInfo();
       return {
         appConfig,
         userConfig,
@@ -141,11 +162,9 @@ export async function getInitialState(): Promise<{
         settings: defaultSettings as Partial<LayoutSettings>,
       };
     } catch (error) {
-      localStorage.removeItem('token');
-      localStorage.removeItem('token.expire');
-      localStorage.removeItem('autoLogin');
+      clearAuthState();
       if (location.pathname !== loginPath) {
-        history.push(loginPath);
+        history.replace(getAuthRedirect(location));
       }
       return {
         appConfig,

--- a/src/pages/User/Login/index.tsx
+++ b/src/pages/User/Login/index.tsx
@@ -224,7 +224,7 @@ const Login: React.FC = () => {
     }
   };
 
-  const { loading } = useRequest(async () => {
+  useRequest(async () => {
     if (
       localStorage.getItem('autoLogin') &&
       localStorage.getItem('token') &&
@@ -317,9 +317,7 @@ const Login: React.FC = () => {
     };
   }, []);
 
-  return loading ? (
-    <></>
-  ) : (
+  return (
     <div className={containerClassName}>
       <Helmet>
         <title>


### PR DESCRIPTION
## Summary
- add timeout guards around authenticated bootstrap requests so stale tokens or a slow beta API do not leave the page blank
- clear stale auth state and redirect to the login page when user info cannot be resolved quickly
- keep the login page visible while autoLogin refresh runs, instead of rendering an empty fragment
- update the beta first-screen incident `aigc` memory with the stale-token/API-timeout layer

## Tests / Validation
- `pnpm tsc`
- `pnpm lint:js`
- `pnpm test -- --runInBand`
- `pnpm build:beta`
- local beta static smoke: `/` renders the login page and uses `#root` with no `root-master`

## Docs Impact
- Updated `aigc/prompts/admin-beta-first-screen-2026-06-11.zh-CN.md` with the stale-token and autoLogin blank-screen findings.

## Security Impact
- No authentication contract or permission model changes.
- Stale/failed auth bootstrap now clears local token state and sends the user back through the existing safe login redirect flow.

## Release / Compatibility Impact
- Patch-level Cloudflare beta frontend fix.
- No backend API contract, storage, or migration changes.
- Rollback is safe by redeploying the previous Cloudflare beta Worker version if needed.

## Known Follow-up
- `admin-api-beta.mss-boot-io.top` still times out / returns Cloudflare 522 from this machine, and `kubectl --kubeconfig ~/.kube/baas.yaml` still hits TLS handshake timeout; backend origin connectivity remains a separate follow-up.
